### PR TITLE
Add Regula to Risk Assessment

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 ### Risk Assessment
 
 - [LogicGate](https://logicgate.com) - Risk Cloud platform with AI-driven risk quantification and automated control assessments.
+- [Regula](https://github.com/kuzivaai/getregula) - Open-source EU AI Act static analysis CLI. Classifies code against risk tiers, maps findings to 12 compliance frameworks. Offline, zero dependencies. Apache 2.0.
 - [Resolver](https://resolver.com) - Integrated risk intelligence platform with AI-powered risk correlation and predictive analytics.
 - [ServiceNow GRC](https://servicenow.com/products/governance-risk-compliance.html) - Enterprise GRC with AI-driven risk insights and automated policy management.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 ### Risk Assessment
 
 - [LogicGate](https://logicgate.com) - Risk Cloud platform with AI-driven risk quantification and automated control assessments.
-- [Regula](https://github.com/kuzivaai/getregula) - Open-source EU AI Act static analysis CLI. Classifies code against risk tiers, maps findings to 12 compliance frameworks. Offline, zero dependencies. Apache 2.0.
+- [Regula](https://github.com/kuzivaai/getregula) - Open-source static analysis CLI that classifies code against EU AI Act risk tiers and maps findings to compliance frameworks.
 - [Resolver](https://resolver.com) - Integrated risk intelligence platform with AI-powered risk correlation and predictive analytics.
 - [ServiceNow GRC](https://servicenow.com/products/governance-risk-compliance.html) - Enterprise GRC with AI-driven risk insights and automated policy management.
 


### PR DESCRIPTION
**Section:** Risk Assessment

**Entry:**
- [Regula](https://github.com/kuzivaai/getregula) - Open-source EU AI Act static analysis CLI. Classifies code against risk tiers, maps findings to 12 compliance frameworks. Offline, zero dependencies. Apache 2.0.

**AI + GRC intersection:** Regula is a static analysis tool that classifies source code against EU AI Act risk tiers and maps every finding to compliance frameworks (ISO 42001, NIST AI RMF, SOC 2, OWASP LLM Top 10, and 8 others). It generates Annex IV documentation scaffolds and conformity evidence packs. Published on PyPI as `regula-ai`, 2,309 passing tests, actively maintained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Regula to the list of Risk Assessment AI-powered tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->