### PR TITLE
Add Nobulex to AI Audit Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - [AuditBoard](https://auditboard.com) - Connected risk platform with AI-powered audit management, SOX compliance, and risk assessment.
 - [Workiva](https://workiva.com) - Cloud platform for audit, risk, and compliance with AI-assisted document analysis and reporting.
 - [MindBridge](https://mindbridge.ai) - AI-powered financial audit analytics detecting anomalies and risks in transactional data.
+- [Nobulex](https://github.com/arian-gogani/nobulex) - Open-source cryptographic receipt layer for AI agent actions. Emits Ed25519-signed, JCS-canonical (RFC 8785) bilateral receipts (admission + outcome) verifiable against the agent's published public key. Targets EU AI Act Article 12 audit-trail requirements. Cited in OWASP CheatSheetSeries and Microsoft AGT ecosystem. MIT licensed.
 
 ### Risk Assessment
 


### PR DESCRIPTION
Adds [Nobulex](https://github.com/arian-gogani/nobulex), an open-source cryptographic receipt layer for AI agent actions, to the AI Audit Tools section.

Different from the commercial GRC platforms already listed (AuditBoard, Workiva, MindBridge): Nobulex is the cryptographic primitive layer underneath audit tooling — it produces the tamper-evident evidence that GRC platforms can ingest. The two compose cleanly rather than compete.

Specific fit for the EU AI Act Article 12 enforcement coming August 2, 2026: regulators verifying high-risk AI systems need logs that survive operator review, which operator-controlled audit logs don't satisfy. Nobulex's bilateral receipt pattern (signed admission + outcome records joined by a content-derived `action_ref`) produces verifiable evidence offline.

Cited:
- OWASP CheatSheetSeries PR #2210 (merged)
- Microsoft Agent Governance Toolkit (integration)
- x402 settlement-receipt extension (PR #2666 §5 cites as third independent issuer)
- agentrust-io/awesome-ai-governance

MIT licensed, no commercial gating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new entry to the AI Audit Tools list for Nobulex.
  * Expanded the resource list with a brief description of its audit-receipt capabilities and compliance focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->