### PR TITLE
Add Markovian audit-anchor (tamper-evident, independently verifiable audit trails)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - [AuditBoard](https://auditboard.com) - Connected risk platform with AI-powered audit management, SOX compliance, and risk assessment.
 - [Workiva](https://workiva.com) - Cloud platform for audit, risk, and compliance with AI-assisted document analysis and reporting.
 - [MindBridge](https://mindbridge.ai) - AI-powered financial audit analytics detecting anomalies and risks in transactional data.
-- [Markovian audit-anchor](https://github.com/MarkovianProtocol/audit-anchor) - Open-source tool that makes any audit trail tamper-evident and independently verifiable: hash-chain the log, commit the head to an external append-only timestamp (RFC 3161 or OpenTimestamps to Bitcoin), and verify offline by recomputation. Maps to record-keeping requirements such as EU AI Act Article 12.
+- [Markovian audit-anchor](https://github.com/MarkovianProtocol/audit-anchor) - Open-source tool for tamper-evident, independently verifiable audit trails, anchored via RFC 3161/OpenTimestamps and verifiable offline. Relevant to record-keeping duties such as EU AI Act Article 12.
 
 ### Risk Assessment
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - [AuditBoard](https://auditboard.com) - Connected risk platform with AI-powered audit management, SOX compliance, and risk assessment.
 - [Workiva](https://workiva.com) - Cloud platform for audit, risk, and compliance with AI-assisted document analysis and reporting.
 - [MindBridge](https://mindbridge.ai) - AI-powered financial audit analytics detecting anomalies and risks in transactional data.
+- [Markovian audit-anchor](https://github.com/MarkovianProtocol/audit-anchor) - Open-source tool that makes any audit trail tamper-evident and independently verifiable: hash-chain the log, commit the head to an external append-only timestamp (RFC 3161 or OpenTimestamps to Bitcoin), and verify offline by recomputation. Maps to record-keeping requirements such as EU AI Act Article 12.
 
 ### Risk Assessment
 


### PR DESCRIPTION
Adds [Markovian audit-anchor](https://github.com/MarkovianProtocol/audit-anchor).

It is an open-source reference implementation of independently verifiable, tamper-evident record integrity: canonicalize a log (RFC 8785), hash and Merkle-bind it, commit the root to an external append-only timestamp (RFC 3161 TSA or OpenTimestamps confirmed on Bitcoin), and verify offline with the stock client, with nothing trusted from the operator. It maps to record-keeping requirements such as EU AI Act Article 12. Thanks for maintaining this list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new entry to the AI Audit Tools list in the README.
  * Included a resource for tamper-evident audit trails with hash-chaining, external timestamping, and verification by recomputation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->