### PR TITLE
Add EU AI Act Obligation-to-Evidence Dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@
 - [NIST AI Risk Management Framework](https://nist.gov/itl/ai-risk-management-framework) - Voluntary US framework for identifying, assessing, and mitigating AI risks with four core functions (Govern, Map, Measure, Manage).
 - [EU AI Act](https://artificialintelligenceact.eu) - European regulation establishing risk-based AI requirements with prohibited practices, high-risk obligations, and transparency rules.
 - [EU AI Act Obligation-to-Evidence Dataset](https://github.com/Kroniquedubaboo/eu-ai-act-obligation-evidence-dataset) - Open, machine-readable dataset mapping EU AI Act obligations to the specific audit evidence, roles, risk tiers, and deadlines; free and open under CC BY 4.0.
-- [EU AI Act Obligation-to-Evidence Dataset](https://github.com/Kroniquedubaboo/eu-ai-act-obligation-evidence-dataset) - Open, machine-readable dataset mapping EU AI Act obligations to the specific audit evidence, roles, risk tiers, and deadlines; free and open under CC BY 4.0.
 - [ISO/IEC 42001](https://iso.org/standard/81230.html) - International standard for AI Management Systems (AIMS) providing certification framework for responsible AI governance.
 - [OECD AI Principles](https://oecd.ai/en/ai-principles) - International guidelines for trustworthy AI covering human-centered values, transparency, and accountability.
 - [Singapore Model AI Governance Framework](https://pdpc.gov.sg/help-and-resources/2020/01/model-ai-governance-framework) - Practical guidance for deploying AI responsibly with implementation examples.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 
 - [NIST AI Risk Management Framework](https://nist.gov/itl/ai-risk-management-framework) - Voluntary US framework for identifying, assessing, and mitigating AI risks with four core functions (Govern, Map, Measure, Manage).
 - [EU AI Act](https://artificialintelligenceact.eu) - European regulation establishing risk-based AI requirements with prohibited practices, high-risk obligations, and transparency rules.
+- [EU AI Act Obligation-to-Evidence Dataset](https://github.com/Kroniquedubaboo/eu-ai-act-obligation-evidence-dataset) - Open, machine-readable dataset mapping EU AI Act obligations to the specific audit evidence, roles, risk tiers, and deadlines; free and open under CC BY 4.0.
 - [ISO/IEC 42001](https://iso.org/standard/81230.html) - International standard for AI Management Systems (AIMS) providing certification framework for responsible AI governance.
 - [OECD AI Principles](https://oecd.ai/en/ai-principles) - International guidelines for trustworthy AI covering human-centered values, transparency, and accountability.
 - [Singapore Model AI Governance Framework](https://pdpc.gov.sg/help-and-resources/2020/01/model-ai-governance-framework) - Practical guidance for deploying AI responsibly with implementation examples.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 - [NIST AI Risk Management Framework](https://nist.gov/itl/ai-risk-management-framework) - Voluntary US framework for identifying, assessing, and mitigating AI risks with four core functions (Govern, Map, Measure, Manage).
 - [EU AI Act](https://artificialintelligenceact.eu) - European regulation establishing risk-based AI requirements with prohibited practices, high-risk obligations, and transparency rules.
 - [EU AI Act Obligation-to-Evidence Dataset](https://github.com/Kroniquedubaboo/eu-ai-act-obligation-evidence-dataset) - Open, machine-readable dataset mapping EU AI Act obligations to the specific audit evidence, roles, risk tiers, and deadlines; free and open under CC BY 4.0.
+- [EU AI Act Obligation-to-Evidence Dataset](https://github.com/Kroniquedubaboo/eu-ai-act-obligation-evidence-dataset) - Open, machine-readable dataset mapping EU AI Act obligations to the specific audit evidence, roles, risk tiers, and deadlines; free and open under CC BY 4.0.
 - [ISO/IEC 42001](https://iso.org/standard/81230.html) - International standard for AI Management Systems (AIMS) providing certification framework for responsible AI governance.
 - [OECD AI Principles](https://oecd.ai/en/ai-principles) - International guidelines for trustworthy AI covering human-centered values, transparency, and accountability.
 - [Singapore Model AI Governance Framework](https://pdpc.gov.sg/help-and-resources/2020/01/model-ai-governance-framework) - Practical guidance for deploying AI responsibly with implementation examples.


### PR DESCRIPTION
Adds one resource under **AI Governance Frameworks → Frameworks and Standards**, right after the existing EU AI Act entry.

**Resource:** [EU AI Act Obligation-to-Evidence Dataset](https://github.com/Kroniquedubaboo/eu-ai-act-obligation-evidence-dataset) — an open, machine-readable dataset that maps EU AI Act obligations to the specific audit evidence a practitioner must produce, together with the applicable roles, risk tiers, deadlines, and common audit red flags.

**Why it fits AI + GRC:** it turns the EU AI Act into a structured obligation → evidence mapping that GRC teams can use directly for compliance and audit preparation — a practical companion to the framework entries already listed (e.g. EU AI Act, MIT AI Risk Repository). Every record cites a primary source; items still being verified are flagged `needs_review` rather than presented as settled.

**Guidelines checklist:**
- Free and open — CC BY 4.0.
- Actively maintained; JSON/CSV formats with an included integrity validator.
- Objective description, format `[Name](link) - Description.`, no trailing slash.
- Not legal advice (stated in the dataset's README).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the EU AI Act Obligation-to-Evidence Dataset to the list of AI governance frameworks and standards resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->