### PR TITLE
Add CATAAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - [Secureframe](https://secureframe.com) - Compliance automation with high-touch guidance for complex multi-framework environments.
 - [Sprinto](https://sprinto.com) - AI-driven compliance automation platform with risk-based prioritization and continuous control monitoring.
 - [Thoropass](https://thoropass.com) - End-to-end compliance platform combining automation software with auditor services.
+- [CATAAM](https://cataam.com) - AI-native GRC platform automating SOC 2, ISO 27001 and ISO 42001 (AI management systems), with AI-system governance, prompt/secret-leak prevention (Prompt Guard), and continuous control monitoring; commercial with a free trial.
 
 ### AI Audit Tools
 


### PR DESCRIPTION
### Add CATAAM

**What:** [CATAAM](https://cataam.com) is an AI-native GRC platform that automates SOC 2, ISO 27001 and **ISO/IEC 42001** (the AI Management System standard), with AI-system governance, prompt/secret-leak prevention (Prompt Guard), and continuous control monitoring. Commercial, with a free trial.

**Why it fits the AI + GRC intersection:** unlike the pure compliance-automation entries, CATAAM's core is governing AI systems themselves — an ISO 42001 AIMS (AI inventory, impact assessments, Annex A control validation) plus AI-security controls that stop secrets and sensitive data leaking into LLMs. It sits squarely at AI × GRC, in the **Compliance Automation** category alongside Drata, Vanta and Sprinto.

**Guidelines checklist:** format `[Name](link) - Description.` ✓ · `-` bullet ✓ · description ends with a period ✓ · no trailing slash on the link ✓ · commercial clearly marked (free trial) ✓ · placed in the appropriate category ✓.

_Disclosure: I'm affiliated with CATAAM._ Happy to adjust wording or category to fit your conventions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CATAAM to the Compliance Automation section.
  * Highlighted support for SOC 2, ISO 27001, ISO 42001, governance, prompt and secret-leak prevention, continuous monitoring, and free-trial availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->