### PR TITLE
Add ISMS Copilot under LLM Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 - [Claude for Enterprise](https://anthropic.com/claude) - AI assistant for policy analysis, compliance document review, and risk assessment workflows.
 - [Microsoft Copilot for Security](https://microsoft.com/security/business/ai-machine-learning/microsoft-copilot-security) - AI-powered security operations with threat intelligence and compliance guidance.
 - [ChatGPT Enterprise](https://openai.com/enterprise) - Secure AI assistant for GRC document analysis, policy drafting, and audit preparation.
+- [ISMS Copilot](https://www.ismscopilot.com/) - Specialized AI assistant for ISO 27001, SOC 2, NIS 2, GDPR, DORA, and related frameworks: policy drafting, risk assessments, control mapping, audit prep. Optional EU-region AI mode. Free tools: [ismscopilot.com/resources](https://www.ismscopilot.com/resources).
 
 ## AI Governance Frameworks
 


### PR DESCRIPTION
Adds ISMS Copilot as a specialized compliance AI assistant under LLM Integrations, next to general-purpose enterprise assistants. Includes a pointer to the free browser tools hub. Not an evidence-automation platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ISMS Copilot to the LLM Integrations list.
  * Documented supported compliance frameworks, capabilities, EU-region AI mode, and free resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->