### PR TITLE
Add Sentinel Scan CLI to AI Audit Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - [AuditBoard](https://auditboard.com) - Connected risk platform with AI-powered audit management, SOX compliance, and risk assessment.
 - [Workiva](https://workiva.com) - Cloud platform for audit, risk, and compliance with AI-assisted document analysis and reporting.
 - [MindBridge](https://mindbridge.ai) - AI-powered financial audit analytics detecting anomalies and risks in transactional data.
+- [Sentinel Scan CLI](https://github.com/Ventrova/sentinel-scan-cli) - Open-source CLI for auditing MCP servers and agentic AI tool manifests. Detects tool poisoning, prompt injection surface, and rug-pulls; OWASP LLM Top 10-mapped findings. MIT, free.
 
 ### Risk Assessment
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - [AuditBoard](https://auditboard.com) - Connected risk platform with AI-powered audit management, SOX compliance, and risk assessment.
 - [Workiva](https://workiva.com) - Cloud platform for audit, risk, and compliance with AI-assisted document analysis and reporting.
 - [MindBridge](https://mindbridge.ai) - AI-powered financial audit analytics detecting anomalies and risks in transactional data.
-- [Sentinel Scan CLI](https://github.com/Ventrova/sentinel-scan-cli) - Open-source CLI for auditing MCP servers and agentic AI tool manifests. Detects tool poisoning, prompt injection surface, and rug-pulls; OWASP LLM Top 10-mapped findings. MIT, free.
+- [Sentinel Scan CLI](https://github.com/Ventrova/sentinel-scan-cli) - Open-source CLI for static scanning of MCP tool manifests and mcpServers configurations (no runtime execution). Detects tool poisoning, prompt injection surface, and rug-pulls; OWASP LLM Top 10-mapped findings. MIT, free. (Disclosure: maintained by the project author.)
 
 ### Risk Assessment
 


### PR DESCRIPTION
Adding Sentinel Scan CLI (https://github.com/Ventrova/sentinel-scan-cli), an open-source CLI that audits MCP servers and agentic AI tool manifests for tool poisoning, prompt injection surface, and rug-pull risk (an AI-specific audit gap not covered by the commercial platforms already listed). OWASP LLM Top 10-mapped findings.

MIT licensed, free CLI.

Disclosure: I'm the maintainer (Ventrova). Happy to adjust wording/placement if it doesn't fit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Sentinel Scan CLI to the AI Audit Tools resource list.
  - Highlights auditing for MCP servers and agentic AI tool manifests.
  - Includes detection of tool poisoning, prompt-injection risks, and rug-pulls.
  - Findings are mapped to the OWASP LLM Top 10 and released under the MIT license.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->