### PR TITLE
Add small-business AI policy template

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Ready-to-use Claude prompts for GRC compliance workflows. See the [`prompts/`](p
 
 Customizable policy templates for AI governance. See the [`templates/`](templates/) directory for customization instructions.
 
-- [BrandQuill Small Business AI Policy Template](https://github.com/loebpaul/small-business-ai-policy-template) - Free editable Word policy pack covering approved AI tools, confidential data, human review, prohibited uses, incidents, and employee acknowledgement.
+- [Small Business AI Acceptable Use Policy Template](https://github.com/loebpaul/small-business-ai-policy-template) - Free editable Word policy pack covering approved AI tools, confidential data, human review, prohibited uses, incidents, and employee acknowledgement.
 - AI Acceptable Use Policy - Guidelines for acceptable use of AI technologies (NIST AI RMF, ISO 42001)
 - AI Risk Assessment Framework - Structured framework for identifying and mitigating AI risks (NIST AI RMF)
 - Model Development Lifecycle Standard - Governance checkpoints for ML model development (MLOps, ISO 42001)

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Ready-to-use Claude prompts for GRC compliance workflows. See the [`prompts/`](p
 
 Customizable policy templates for AI governance. See the [`templates/`](templates/) directory for customization instructions.
 
+- [BrandQuill Small Business AI Policy Template](https://github.com/loebpaul/small-business-ai-policy-template) - Free editable Word policy pack covering approved AI tools, confidential data, human review, prohibited uses, incidents, and employee acknowledgement.
 - AI Acceptable Use Policy - Guidelines for acceptable use of AI technologies (NIST AI RMF, ISO 42001)
 - AI Risk Assessment Framework - Structured framework for identifying and mitigating AI risks (NIST AI RMF)
 - Model Development Lifecycle Standard - Governance checkpoints for ML model development (MLOps, ISO 42001)


### PR DESCRIPTION
Adds a free, MIT-licensed, editable Word policy pack to the Templates section. It gives small teams practical rules for approved AI tools, confidential data, human review, prohibited uses, incident reporting, and employee acknowledgement.

This fits the AI and GRC intersection because it turns AI governance principles into a policy that a small business can customize and roll out. The repository is actively maintained, the files are downloadable without signup, and the source is publicly reviewable.

Disclosure: I maintain BrandQuill and the linked resource.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the BrandQuill Small Business AI Policy Template to the list of available templates.
  * Linked to a free, editable Word policy pack covering AI tools, data handling, human review, prohibited uses, incidents, and employee acknowledgement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->