### PR TITLE
Add RansomLeak Compliance Training to GRC Fundamentals

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@
 - [LinkedIn Learning GRC Path](https://linkedin.com/learning/topics/governance-risk-and-compliance) - Curated learning path for GRC fundamentals including risk assessment and audit.
 - [Pluralsight Security Compliance](https://pluralsight.com/browse/information-cyber-security/compliance) - Technical compliance training for security professionals entering GRC.
 - [ISACA Learning](https://isaca.org/training-and-events) - Professional development in audit, risk, governance, and cybersecurity.
+- [RansomLeak Compliance Training](https://ransomleak.com/catalogue/privacy-compliance/) - Interactive employee training mapped to GDPR, EU AI Act, NIS2, ISO 27001, HIPAA, and SOC 2 awareness requirements.
 
 ## Prompts
 


### PR DESCRIPTION
Adds RansomLeak to GRC Fundamentals next to SANS Security Awareness. It is interactive employee training whose privacy and compliance catalogue covers GDPR (18 exercises), the EU AI Act (15 exercises), and the OWASP Top 10 Privacy Risks, with additional awareness content mapped to NIS2, ISO 27001, HIPAA, and SOC 2.

Disclosure: I work on RansomLeak. The link returns 200 and the catalogue is browsable without an account. Formatting follows the surrounding entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added RansomLeak Compliance Training to the GRC Fundamentals resource list.
  - Included a link to the training page and details about coverage of GDPR, the EU AI Act, NIS2, ISO 27001, HIPAA, and SOC 2 awareness requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->